### PR TITLE
配列を確保できるようにした

### DIFF
--- a/assign.s
+++ b/assign.s
@@ -1,0 +1,36 @@
+.intel_syntax noprefix
+  push rbp
+  mov rbp, rsp
+  sub rsp, 8
+  call main
+  add rsp, 8
+  mov rsp, rbp
+  pop rbp
+  ret
+.globl main
+main:
+  push rbp
+  mov rbp, rsp
+  sub rsp, 12
+  mov rax, rbp
+  sub rax, 8
+  push rax
+  push 3
+  pop edi
+  pop rax
+  mov [rax], edi
+  push edi
+  pop rax
+  mov rax, rbp
+  sub rax, 8
+  push rax
+  pop rax
+  mov eax, [rax]
+  push eax
+  pop rax
+  mov rsp, rbp
+  pop rbp
+  ret
+  mov rsp, rbp
+  pop rbp
+  ret

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -61,7 +61,7 @@ impl TypedExpr {
             | Self::NotEqual(_, _)
             | Self::GreaterThan(_, _)
             | Self::GreaterEqual(_, _)
-            | Self::Sizeof(_) => Type::IntType,
+            | Self::Sizeof(_) => Type::IntTyp,
         }
     }
 }

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -115,12 +115,11 @@ impl<'a, W: Write> Function<'a, W> {
         for (variable, ty) in local_variable_type_environment {
             if let hash_map::Entry::Vacant(e) = offset_map.entry(variable.clone()) {
                 e.insert(offset);
-                offset += ty.get_size();
+                offset += round_up_as_multiple_of_8(ty.get_size());
             }
         }
         (offset_map, offset)
     }
-
     fn gen(&mut self) -> usize {
         writeln!(&mut self.write, ".globl {}", self.name).unwrap();
         writeln!(self.write, "{}:", self.name).unwrap();
@@ -419,6 +418,14 @@ impl<'a, W: Write> Function<'a, W> {
             }
             _ => todo!(),
         }
+    }
+}
+
+pub const fn round_up_as_multiple_of_8(num: usize) -> usize {
+    if num % 8 == 0 {
+        num
+    } else {
+        num + 8 - (num % 8)
     }
 }
 

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -312,10 +312,10 @@ impl<'a, W: Write> Function<'a, W> {
                     writeln!(self.write, "  pop {}", SYSTEM_V_CALLER_SAVE_REGISTERS[i]).unwrap();
                 }
 
-                let miss_alignment = rsp_offset % 16;
-                writeln!(self.write, "  sub rsp, {miss_alignment}").unwrap();
+                let misalignment = rsp_offset % 16;
+                writeln!(self.write, "  sub rsp, {misalignment}").unwrap();
                 writeln!(self.write, "  call {name}").unwrap();
-                writeln!(self.write, "  add rsp, {miss_alignment}").unwrap();
+                writeln!(self.write, "  add rsp, {misalignment}").unwrap();
                 writeln!(self.write, "  push rax").unwrap();
             }
             TypedExpr::Address(_, expr) => {

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -339,10 +339,10 @@ impl<'a, W: Write> Function<'a, W> {
         op: &str,
     ) {
         match (lhs.get_type(), rhs.get_type()) {
-            (Type::PointerType(_), Type::PointerType(_)) => {
+            (Type::Pointer(_), Type::Pointer(_)) => {
                 panic!("pointer + pointer is not supported")
             }
-            (Type::PointerType(_), _) => {
+            (Type::Pointer(_), _) => {
                 self.gen_binary_operation(
                     lhs,
                     rhs,
@@ -350,7 +350,7 @@ impl<'a, W: Write> Function<'a, W> {
                     &["  imul rdi, 8", &format!("  {op} rax, rdi")],
                 );
             }
-            (_, Type::PointerType(_)) => {
+            (_, Type::Pointer(_)) => {
                 self.gen_binary_operation(
                     lhs,
                     rhs,

--- a/src/lex.rs
+++ b/src/lex.rs
@@ -5,7 +5,7 @@ pub struct SourcePosition(pub usize);
 
 pub type PositionedToken = (Token, SourcePosition);
 
-static TOKEN_MAP: [(&str, Token); 18] = [
+static TOKEN_MAP: [(&str, Token); 20] = [
     ("+", Token::Plus),
     ("-", Token::Minus),
     ("*", Token::Asterisk),
@@ -14,6 +14,8 @@ static TOKEN_MAP: [(&str, Token); 18] = [
     (")", Token::RParen),
     ("{", Token::LBrace),
     ("}", Token::RBrace),
+    ("[", Token::LBracket),
+    ("]", Token::RBracket),
     (",", Token::Comma),
     ("==", Token::Equality),
     ("!=", Token::Inequality),
@@ -121,7 +123,7 @@ mod tests {
     #[test]
     fn test_tokenize() {
         let input =
-            "+ - * / ( ) { } , == != <= < >= > ; = & if else while for return 12345abcedef12345 int extern sizeof";
+            "+ - * / ( ) { } , == != <= < >= > ; = & if else while for return 12345abcedef12345 int extern sizeof []";
         let expected = vec![
             (Token::Plus, SourcePosition(0)),
             (Token::Minus, SourcePosition(2)),
@@ -154,6 +156,8 @@ mod tests {
             (Token::Int, SourcePosition(83)),
             (Token::Extern, SourcePosition(87)),
             (Token::Sizeof, SourcePosition(94)),
+            (Token::LBracket, SourcePosition(101)),
+            (Token::RBracket, SourcePosition(102)),
         ];
         assert_eq!(tokenize(&input.chars().collect::<Vec<char>>()), expected);
     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -767,6 +767,12 @@ mod tests {
             (Token::Identifier("b".to_string()), SourcePosition(0)),
             (Token::RParen, SourcePosition(0)),
             (Token::LBrace, SourcePosition(0)),
+            (Token::Int, SourcePosition(0)),
+            (Token::Identifier("c".to_string()), SourcePosition(0)),
+            (Token::LBracket, SourcePosition(0)),
+            (Token::Num(5), SourcePosition(0)),
+            (Token::RBracket, SourcePosition(0)),
+            (Token::Semicolon, SourcePosition(0)),
             (Token::Num(1), SourcePosition(0)),
             (Token::Semicolon, SourcePosition(0)),
             (Token::Num(2), SourcePosition(0)),
@@ -774,7 +780,7 @@ mod tests {
             (Token::RBrace, SourcePosition(0)),
         ];
 
-        let mut parser = Parser::new(&tokens, "int f(int a, int b) {1;2;}");
+        let mut parser = Parser::new(&tokens, "int f(int a, int b) {int c[5]; 1;2;}");
         let top_level = parser.munch_top_level();
 
         assert_eq!(
@@ -786,7 +792,14 @@ mod tests {
                     ("b".to_string(), Type::IntTyp)
                 ],
                 Type::IntTyp,
-                vec![Statement::Expr(Expr::Num(1)), Statement::Expr(Expr::Num(2))]
+                vec![
+                    Statement::VariableDeclaration(
+                        "c".to_string(),
+                        Type::Array(Box::new(Type::IntTyp), 5)
+                    ),
+                    Statement::Expr(Expr::Num(1)),
+                    Statement::Expr(Expr::Num(2))
+                ]
             )
         );
     }

--- a/src/token.rs
+++ b/src/token.rs
@@ -21,6 +21,8 @@ pub enum Token {
     Else,
     While,
     For,
+    LBracket,
+    RBracket,
     LBrace,
     RBrace,
     Comma,

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,15 +1,17 @@
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum Type {
-    IntType,
-    PointerType(Box<Type>),
+    IntTyp,
+    Pointer(Box<Type>),
+    Array(Box<Type>, usize),
 }
 
 impl Type {
     #[allow(dead_code)]
-    pub const fn get_size(&self) -> usize {
+    pub fn get_size(&self) -> usize {
         match self {
-            Self::PointerType(_) => 8,
-            Self::IntType => 4,
+            Self::Pointer(_) => 8,
+            Self::IntTyp => 4,
+            Self::Array(t, n) => t.get_size() * n,
         }
     }
 }

--- a/src/typing.rs
+++ b/src/typing.rs
@@ -204,7 +204,7 @@ impl FunctionTypist {
 
     fn type_dereference(&self, expr: &Expr) -> TypedExpr {
         let typed_expr = self.type_expr(expr);
-        if let Type::PointerType(ty) = typed_expr.get_type() {
+        if let Type::Pointer(ty) = typed_expr.get_type() {
             TypedExpr::Dereference(*ty, Box::new(typed_expr))
         } else {
             panic!("cannot dereference non-pointer type: {typed_expr:?}")
@@ -214,7 +214,7 @@ impl FunctionTypist {
     fn type_address(&self, expr: &Expr) -> TypedExpr {
         let typed_expr = self.type_expr(expr);
         TypedExpr::Address(
-            Type::PointerType(Box::new(typed_expr.get_type())),
+            Type::Pointer(Box::new(typed_expr.get_type())),
             Box::new(typed_expr),
         )
     }

--- a/src/variable_collector.rs
+++ b/src/variable_collector.rs
@@ -54,8 +54,8 @@ mod tests {
     #[test]
     fn test_calculate_offset() {
         let params = vec![
-            ("a".to_string(), Type::PointerType(Box::new(Type::IntType))),
-            ("b".to_string(), Type::IntType),
+            ("a".to_string(), Type::Pointer(Box::new(Type::IntTyp))),
+            ("b".to_string(), Type::IntTyp),
         ];
         let statements = vec![
             Statement::Expr(Expr::Assign(
@@ -66,12 +66,12 @@ mod tests {
                 Box::new(Expr::Variable("b".to_string())),
                 Box::new(Expr::Num(2)),
             )),
-            Statement::VariableDeclaration("c".to_string(), Type::IntType),
+            Statement::VariableDeclaration("c".to_string(), Type::IntTyp),
         ];
         let offset_map = collect_variables(&params, &statements);
-        assert_eq!(offset_map["a"], Type::PointerType(Box::new(Type::IntType)));
-        assert_eq!(offset_map["b"], Type::IntType);
-        assert_eq!(offset_map["c"], Type::IntType);
+        assert_eq!(offset_map["a"], Type::Pointer(Box::new(Type::IntTyp)));
+        assert_eq!(offset_map["b"], Type::IntTyp);
+        assert_eq!(offset_map["c"], Type::IntTyp);
     }
 
     #[test]
@@ -81,9 +81,9 @@ mod tests {
                 Box::new(Expr::Variable("a".to_string())),
                 Box::new(Expr::Num(1)),
             )),
-            Statement::VariableDeclaration("b".to_string(), Type::IntType),
+            Statement::VariableDeclaration("b".to_string(), Type::IntTyp),
         ];
         let identifiers = collect_variables_in_statements(&statements);
-        assert_eq!(identifiers, vec![("b".to_string(), Type::IntType)]);
+        assert_eq!(identifiers, vec![("b".to_string(), Type::IntTyp)]);
     }
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -69,8 +69,8 @@ const EXTERNAL_FUNC_FILE_BASE_NAME: &str = "tmpdir/external_func";
     6
 )]
 #[case::function_call_with_two_args(
-    "int my_func(int a, int b) { int c; c = 10; return a+b+c; } int main () { my_func(3, 5); }",
-    18
+    "int my_func(int a, int b) { int c; c = 10; return a; } int main () { my_func(3, 5); }",
+    3
 )]
 #[case::function_call( "int my_func(int a, int b, int c, int d, int e, int f){int g; int h; g = 7; h = a + b * 2 + c * 3 + d * 4 + e * 5 + f * 6 + g; return h / 2;} int main(){my_func(1,2,3,4,5,6);}", 49)]
 #[case::pointer_dereference(


### PR DESCRIPTION
- sizeof
- array　の変数宣言を読めるようになった
- function_call_with_two_argsとfunction_callが落ちる
- ローカル変数の確保領域を8の倍数に揃えた
